### PR TITLE
WIP: Add initial website section to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,5 +81,10 @@ services:
     environment:
       - FHIR_SERVICE_URL=${FHIR_SERVICE_URL}
 
+  website:
+    # TODO Add Website's static build configuration here
+    environment:
+      - FOO=BAR
+
 volumes:
   hapi-fhir-postgres:


### PR DESCRIPTION
# Overview 🌀  

This PR adds support for bundling the static build of the [FHIR Aggregator website](https://github.com/FHIR-Aggregator/website) into the docker-compose environment for easier and more robust deployments!

## Previous Behavior :x:

```sh
➜ bar
```

## New Behavior ✅ 

```sh
➜ foo
```

## Testing Steps 🧪 

```sh
➜ baz
``` 

# Additional Resources 📚 

- https://nextjs.org/docs/pages/building-your-application/deploying/static-exports
- https://cloud.google.com/storage/docs/hosting-static-website#console